### PR TITLE
[attr]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.attr?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # attr
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# attr
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/getfattr'

--- a/controls/attr_exists.rb
+++ b/controls/attr_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm acl exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'attr')
+ 
+control 'core-plans-attr-exists' do
+  impact 1.0
+  title 'Ensure attr exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/getfattr')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/attr_exists.rb
+++ b/controls/attr_exists.rb
@@ -1,4 +1,4 @@
-title 'Tests to confirm acl exists'
+title 'Tests to confirm attr exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'attr')
@@ -7,7 +7,8 @@ control 'core-plans-attr-exists' do
   impact 1.0
   title 'Ensure attr exists'
   desc '
-  '
+  Verify attr by ensuring /bin/getfattr exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/attr_works.rb
+++ b/controls/attr_works.rb
@@ -1,4 +1,4 @@
-title 'Tests to confirm acl works as expected'
+title 'Tests to confirm attr works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'attr')
@@ -7,7 +7,10 @@ control 'core-plans-attr-works' do
   impact 1.0
   title 'Ensure attr works as expected'
   desc '
+  Verify attr by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/attr_works.rb
+++ b/controls/attr_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm acl works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'attr')
+
+control 'core-plans-attr-works' do
+  impact 1.0
+  title 'Ensure attr works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} getfattr --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /getfattr #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: attr
+title: Habitat Core Plan attr
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan attr
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,39 @@
+pkg_name=attr
+pkg_origin=core
+pkg_version=2.4.48
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Commands for Manipulating Filesystem Extended Attributes"
+pkg_upstream_url="https://savannah.nongnu.org/projects/attr/"
+pkg_license=('GPL-2.0-or-later')
+pkg_source="http://download.savannah.gnu.org/releases/${pkg_name}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="5ead72b358ec709ed00bbf7a9eaef1654baad937c001c044fe8b74c57f5324e7"
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/diffutils
+  core/make
+  core/gcc
+  core/gettext
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_install() {
+  make install
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} getfattr --version | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/attr/2.4.48/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://a2f1d0c739030472c2bceb8a98a9561205874cb428e36bce2019da05d64dd62f --input-file /src/attributes.yml

Profile: Habitat Core Plan attr (attr)
Version: 0.1.0
Target:  docker://a2f1d0c739030472c2bceb8a98a9561205874cb428e36bce2019da05d64dd62f

  ✔  core-plans-attr-works: Ensure attr works as expected
     ✔  Command: `hab pkg path core/attr` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/attr` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/attr/2.4.48/20200603125233 getfattr --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/attr/2.4.48/20200603125233 getfattr --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/attr/2.4.48/20200603125233 getfattr --version` stdout is expected to match /getfattr 2.4.48/
     ✔  Command: `DEBUG=true; hab pkg exec core/attr/2.4.48/20200603125233 getfattr --version` stderr is expected to be empty
  ✔  core-plans-attr-exists: Ensure attr exists
     ✔  File /hab/pkgs/core/attr/2.4.48/20200603125233/bin/getfattr is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[9][default:/src:0]# 
```